### PR TITLE
Allow check in for Individual Events 

### DIFF
--- a/src/Tribe/Api_Handler.php
+++ b/src/Tribe/Api_Handler.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * Generates Per Event API and handles API calls from the QR Code app.
+ *
+ * @since 1.0.0
+ *
+ * @package Tribe\Extensions\Per_Event_Checkin;
+ */
+
+namespace Tribe\Extensions\Per_Event_Checkin;
+
+/**
+ * Class API_Handler.
+ *
+ * @since 1.0.0
+ *
+ * @package Tribe\Extensions\Per_Event_Checkin;
+ */
+class Api_Handler {
+
+	/**
+     * Generate API code for Event with Tickets/RSVP.
+     *
+	 * @param int $post_id Event or Post ID.
+	 */
+	public function generate_api_code_for_event( $post_id ) {
+
+		$api_meta_key = '_et_event_api_key';
+
+		$api_key = get_post_meta( $post_id, $api_meta_key, true );
+
+		// If API key is already generated, return.
+		if ( ! empty( $api_key ) ) {
+			return;
+		}
+
+		$qr_settings = tribe( 'tickets-plus.qr.site-settings' );
+
+		$api_key = $qr_settings->generate_new_api();
+
+		update_post_meta( $post_id, $api_meta_key, $api_key );
+	}
+
+	/**
+     * Filter the API key validation for Check in Request.
+     *
+	 * @param bool  $is_valid Whether the requested API Key is valid or not.
+	 * @param array $qr_data Request data array.
+	 *
+	 * @return bool
+	 */
+	function alter_default_api_with_event_api( $is_valid, $qr_data ) {
+
+		if ( ! isset( $qr_data['api_key'] ) ) {
+			return $is_valid;
+		}
+
+		$api_meta_key = '_et_event_api_key';
+		$requested_api = $qr_data['api_key'];
+
+		$args = [
+			'post_type'  => 'any',
+			'meta_key'   => $api_meta_key,
+			'meta_query' => [
+				'key'   => $api_meta_key,
+				'value' => $requested_api,
+			]
+		];
+
+		$posts = get_posts( $args );
+
+		if ( empty( $posts ) || count( $posts ) > 1 ) {
+			return $is_valid;
+		}
+
+		if ( $posts[0]->ID != $qr_data['event_id'] ) {
+			return $is_valid;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Add the Event API meta box to Edit screen.
+	 */
+	public function add_event_api_meta_box() {
+		$post = get_post();
+
+		// Get list of supported post types for Tickets.
+		$supported_post_types = (array) tribe_get_option( 'ticket-enabled-post-types', [] );
+
+		if ( ! in_array( $post->post_type, $supported_post_types ) ) {
+			return;
+		}
+
+		add_meta_box(
+			'event_tickets_event_api',
+			'Event Check-in API',
+			[ $this, 'render_event_tickets_api_meta_box' ],
+			null,
+			'side'
+		);
+	}
+
+	/**
+     * Show a meta box with the Event API key.
+     *
+	 * @param \WP_Post $post Current post Object.
+	 */
+	function render_event_tickets_api_meta_box( $post ) {
+
+	    $api_meta_key = '_et_event_api_key';
+		$api_key      = get_post_meta( $post->ID, $api_meta_key, true );
+
+		if ( empty( $api_key ) ) {
+		    return;
+        }
+
+		?>
+		<input type="text" disabled value="<?php esc_attr_e( $api_key ); ?>">
+		<p class="help-block">Copy this API into the QR Code app to allow checkin for this Event Only.</p>
+		<?php
+	}
+}

--- a/src/Tribe/Api_Handler.php
+++ b/src/Tribe/Api_Handler.php
@@ -36,7 +36,7 @@ class Api_Handler {
 		if ( ! empty( $api_key ) ) {
 			return;
 		}
-
+        /** @var \Tribe__Tickets_Plus__QR__Settings $qr_settings */
 		$qr_settings = tribe( 'tickets-plus.qr.site-settings' );
 
 		$api_key = $qr_settings->generate_new_api();
@@ -65,21 +65,22 @@ class Api_Handler {
 
 		$requested_api = $qr_data['api_key'];
 
-		$args = [
-			'post_type'  => 'any',
-			'meta_key'   => $this->api_meta_key,
-			'meta_query' => [
-				'key'   => $this->api_meta_key,
-				'value' => $requested_api,
-			]
-		];
+        $args = [
+            'post_type'  => 'any',
+            'meta_key'   => $this->api_meta_key,
+            'meta_query' => [
+                'key'   => $this->api_meta_key,
+                'value' => $requested_api,
+            ]
+        ];
 
 		$posts = get_posts( $args );
 
+		// If no events are found for given API key, return original status.
 		if ( empty( $posts ) || count( $posts ) > 1 ) {
 			return $is_valid;
 		}
-
+        // If found event is not same as requested event, bail out.
 		if ( $posts[0]->ID != $qr_data['event_id'] ) {
 			return $is_valid;
 		}
@@ -97,21 +98,21 @@ class Api_Handler {
 		$supported_post_types = (array) tribe_get_option( 'ticket-enabled-post-types', [] );
 
 		if ( ! in_array( $post->post_type, $supported_post_types ) ) {
-			return;
+            return;
 		}
 
 		$api_key = get_post_meta( $post->ID, $this->api_meta_key, true );
 
 		if ( empty( $api_key ) ) {
-			return;
+            return;
 		}
 
 		add_meta_box(
-			'event_tickets_event_api',
-			__( 'Event Check-in API', 'et-per-event-checkin' ),
-			[ $this, 'render_event_tickets_api_meta_box' ],
-			null,
-			'side'
+            'event_tickets_event_api',
+            __( 'Event Check-in API', 'et-per-event-checkin' ),
+            [ $this, 'render_event_tickets_api_meta_box' ],
+            null,
+            'side'
 		);
 	}
 

--- a/src/Tribe/Api_Handler.php
+++ b/src/Tribe/Api_Handler.php
@@ -19,15 +19,18 @@ namespace Tribe\Extensions\Per_Event_Checkin;
 class Api_Handler {
 
 	/**
+     * Meta key name for storing Event API key.
+	 */
+    public $api_meta_key = '_et_event_api_key';
+
+	/**
      * Generate API code for Event with Tickets/RSVP.
      *
 	 * @param int $post_id Event or Post ID.
 	 */
 	public function generate_api_code_for_event( $post_id ) {
 
-		$api_meta_key = '_et_event_api_key';
-
-		$api_key = get_post_meta( $post_id, $api_meta_key, true );
+		$api_key = get_post_meta( $post_id, $this->api_meta_key, true );
 
 		// If API key is already generated, return.
 		if ( ! empty( $api_key ) ) {
@@ -38,7 +41,7 @@ class Api_Handler {
 
 		$api_key = $qr_settings->generate_new_api();
 
-		update_post_meta( $post_id, $api_meta_key, $api_key );
+		update_post_meta( $post_id, $this->api_meta_key, $api_key );
 	}
 
 	/**
@@ -50,6 +53,11 @@ class Api_Handler {
 	 * @return bool
 	 */
 	function alter_default_api_with_event_api( $is_valid, $qr_data ) {
+
+	    // If already valid, bail out.
+	    if ( $is_valid ) {
+	        return $is_valid;
+        }
 
 		if ( ! isset( $qr_data['api_key'] ) ) {
 			return $is_valid;
@@ -93,9 +101,15 @@ class Api_Handler {
 			return;
 		}
 
+		$api_key = get_post_meta( $post->ID, $this->api_meta_key, true );
+
+		if ( empty( $api_key ) ) {
+			return;
+		}
+
 		add_meta_box(
 			'event_tickets_event_api',
-			'Event Check-in API',
+			__( 'Event Check-in API', 'et-per-event-checkin' ),
 			[ $this, 'render_event_tickets_api_meta_box' ],
 			null,
 			'side'
@@ -109,16 +123,12 @@ class Api_Handler {
 	 */
 	function render_event_tickets_api_meta_box( $post ) {
 
-	    $api_meta_key = '_et_event_api_key';
-		$api_key      = get_post_meta( $post->ID, $api_meta_key, true );
+		$api_key = get_post_meta( $post->ID, $this->api_meta_key, true );
 
-		if ( empty( $api_key ) ) {
-		    return;
-        }
-
+		$kb_url = 'https://theeventscalendar.com/knowledgebase/k/using-qr-codes-with-event-tickets-plus/';
 		?>
 		<input type="text" disabled value="<?php esc_attr_e( $api_key ); ?>">
-		<p class="help-block">Copy this API into the QR Code app to allow checkin for this Event Only.</p>
+		<p><?php printf( wp_kses( 'Copy this API into the <a href="%s" target="_blank" rel="noopener noreferrer">QR Code app</a> to allow checkin for this Event Only.', 'et-per-event-checkin' ), esc_attr( $kb_url ) ); ?></p>
 		<?php
 	}
 }

--- a/src/Tribe/Api_Handler.php
+++ b/src/Tribe/Api_Handler.php
@@ -63,14 +63,13 @@ class Api_Handler {
 			return $is_valid;
 		}
 
-		$api_meta_key = '_et_event_api_key';
 		$requested_api = $qr_data['api_key'];
 
 		$args = [
 			'post_type'  => 'any',
-			'meta_key'   => $api_meta_key,
+			'meta_key'   => $this->api_meta_key,
 			'meta_query' => [
-				'key'   => $api_meta_key,
+				'key'   => $this->api_meta_key,
 				'value' => $requested_api,
 			]
 		];

--- a/src/Tribe/Api_Handler.php
+++ b/src/Tribe/Api_Handler.php
@@ -125,10 +125,17 @@ class Api_Handler {
 
 		$api_key = get_post_meta( $post->ID, $this->api_meta_key, true );
 
-		$kb_url = 'https://theeventscalendar.com/knowledgebase/k/using-qr-codes-with-event-tickets-plus/';
+		$kb_url  = 'https://theeventscalendar.com/knowledgebase/k/using-qr-codes-with-event-tickets-plus/';
+		$kb_link = '<a href="' . esc_url( $kb_url ) . '" target="_blank" rel="noopener noreferrer">' . esc_html__( 'QR Code App', 'et-per-event-checkin' ) . '</a>';
 		?>
-		<input type="text" disabled value="<?php esc_attr_e( $api_key ); ?>">
-		<p><?php printf( wp_kses( 'Copy this API into the <a href="%s" target="_blank" rel="noopener noreferrer">QR Code app</a> to allow checkin for this Event Only.', 'et-per-event-checkin' ), esc_attr( $kb_url ) ); ?></p>
+		<input
+            type="text"
+            disabled
+            value="<?php esc_attr_e( $api_key ); ?>"
+        >
+		<p>
+            <?php printf( esc_html__( 'Copy this API into the %s to allow checkin for this Event Only.', 'et-per-event-checkin' ), $kb_link ); ?>
+        </p>
 		<?php
 	}
 }

--- a/src/Tribe/Hooks.php
+++ b/src/Tribe/Hooks.php
@@ -52,6 +52,8 @@ class Hooks extends \tad_DI52_ServiceProvider {
 	 */
 	protected function add_actions() {
 		add_action( 'tribe_load_text_domains', [ $this, 'load_text_domains' ] );
+		add_action( 'tribe_tickets_ticket_added', tribe_callback( 'extension.per_event_checkin.api_handler', 'generate_api_code_for_event' ) );
+		add_action( 'add_meta_boxes', tribe_callback( 'extension.per_event_checkin.api_handler', 'add_event_api_meta_box' ) );
 	}
 
 	/**
@@ -60,7 +62,7 @@ class Hooks extends \tad_DI52_ServiceProvider {
 	 * @since 1.0.0
 	 */
 	protected function add_filters() {
-
+		add_filter( 'event_tickets_plus_requested_api_is_valid', tribe_callback( 'extension.per_event_checkin.api_handler', 'alter_default_api_with_event_api' ), 10, 2 );
 	}
 
 	/**

--- a/src/Tribe/Plugin.php
+++ b/src/Tribe/Plugin.php
@@ -74,6 +74,7 @@ class Plugin extends \tad_DI52_ServiceProvider {
 		$this->container->singleton( static::class, $this );
 		$this->container->singleton( 'extension.per_event_checkin', $this );
 		$this->container->singleton( 'extension.per_event_checkin.plugin', $this );
+		$this->container->singleton( 'extension.per_event_checkin.api_handler', Api_Handler::class );
 
 		if ( ! $this->check_plugin_dependencies() ) {
 			// If the plugin dependency manifest is not met, then bail and stop here.


### PR DESCRIPTION
This extension generates separate API keys for each event with Tickets/RSVPs.

So, that customers can allow check-in for any particular Event using the Event Tickets Plus App. They just need to use the Event's API in the app instead of using the Global API key from settings.

<img width="1343" alt="Screen Shot 2021-05-03 at 4 14 28 PM" src="https://user-images.githubusercontent.com/7523321/116865105-cf36a180-ac2a-11eb-9574-3ec232341686.png">
