### PR TITLE
Community Tickets Integration and Bug fixes

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -33,7 +33,8 @@ We're always interested in your feedback and our [Help Desk](https://support.the
 == Changelog ==
 
 = [1.1.0] TBD =
-
+* Enhancement - Added Community Tickets integration.
+* Fix - Fixed metabox not showing up for new events.
 
 = [1.0.0] 2021-05-08 =
 

--- a/src/Tribe/Api_Handler.php
+++ b/src/Tribe/Api_Handler.php
@@ -104,7 +104,7 @@ class Api_Handler {
 		$api_key = get_post_meta( $post->ID, $this->api_meta_key, true );
 
 		if ( empty( $api_key ) ) {
-			return;
+			$this->generate_api_code_for_event( $post->ID );
 		}
 
 		add_meta_box(

--- a/src/Tribe/Api_Handler.php
+++ b/src/Tribe/Api_Handler.php
@@ -153,6 +153,15 @@ class Api_Handler {
 			return;
 		}
 
+		$uri = $_SERVER[ 'REQUEST_URI' ];
+
+		// Don't display if not on edit page.
+		if (
+			false === stripos( $uri, '/event/' )
+		) {
+			return;
+		}
+
 		// Maybe generate API key if needed.
 		$this->generate_api_code_for_event( $post->ID );
 		?>

--- a/src/Tribe/Api_Handler.php
+++ b/src/Tribe/Api_Handler.php
@@ -153,8 +153,8 @@ class Api_Handler {
 			return;
 		}
 
-		// Don't display if not on edit page or REQUEST_URI not set.
-		if ( !isset($_SERVER[ 'REQUEST_URI' ]) || false === stripos($_SERVER[ 'REQUEST_URI' ], '/event/' )) {
+		// Don't display if not on community edit page.
+		if ( ! tribe_is_community_edit_event_page() ) {
 			return;
 		}
 
@@ -164,9 +164,7 @@ class Api_Handler {
 		<div id="tickets-api" class="tribe-section tribe-section-api-key">
 			<div class="tribe-section-header">
 				<h3>
-					<?php
-					esc_html_e( 'Event API Key', 'et-per-event-checkin' );
-					?>
+					<?php esc_html_e( 'Event API Key', 'et-per-event-checkin' ); ?>
 				</h3>
 			</div>
 			<div class="tribe-section-content">

--- a/src/Tribe/Api_Handler.php
+++ b/src/Tribe/Api_Handler.php
@@ -138,4 +138,38 @@ class Api_Handler {
 		</p>
 		<?php
 	}
+
+	/**
+	 * Show API key box for Event on Community Event edit page.
+	 *
+	 * @since 1.1.0
+	 */
+	function add_community_tickets_api_box() {
+
+		$post = get_post();
+
+		// Only display the API box if we are editing a valid post.
+		if ( ! $post ) {
+			return;
+		}
+
+		// Maybe generate API key if needed.
+		$this->generate_api_code_for_event( $post->ID );
+		?>
+		<div id="tickets-api" class="tribe-section tribe-section-api-key">
+			<div class="tribe-section-header">
+				<h3>
+					<?php
+					esc_html_e( 'Event API Key', 'et-per-event-checkin' );
+					?>
+				</h3>
+			</div>
+			<div class="tribe-section-content">
+				<?php
+					$this->render_event_tickets_api_meta_box( $post );
+				?>
+			</div>
+		</div>
+		<?php
+	}
 }

--- a/src/Tribe/Api_Handler.php
+++ b/src/Tribe/Api_Handler.php
@@ -153,12 +153,8 @@ class Api_Handler {
 			return;
 		}
 
-		$uri = $_SERVER[ 'REQUEST_URI' ];
-
-		// Don't display if not on edit page.
-		if (
-			false === stripos( $uri, '/event/' )
-		) {
+		// Don't display if not on edit page or REQUEST_URI not set.
+		if ( !isset($_SERVER[ 'REQUEST_URI' ]) || false === stripos($_SERVER[ 'REQUEST_URI' ], '/event/' )) {
 			return;
 		}
 
@@ -174,9 +170,7 @@ class Api_Handler {
 				</h3>
 			</div>
 			<div class="tribe-section-content">
-				<?php
-					$this->render_event_tickets_api_meta_box( $post );
-				?>
+				<?php $this->render_event_tickets_api_meta_box( $post ); ?>
 			</div>
 		</div>
 		<?php

--- a/src/Tribe/Hooks.php
+++ b/src/Tribe/Hooks.php
@@ -54,6 +54,9 @@ class Hooks extends \tad_DI52_ServiceProvider {
 		add_action( 'tribe_load_text_domains', [ $this, 'load_text_domains' ] );
 		add_action( 'tribe_tickets_ticket_added', tribe_callback( 'extension.per_event_checkin.api_handler', 'generate_api_code_for_event' ) );
 		add_action( 'add_meta_boxes', tribe_callback( 'extension.per_event_checkin.api_handler', 'add_event_api_meta_box' ) );
+
+		// Add Community Ticket Integration.
+		add_action( 'tribe_post_get_template_part_community-tickets/modules/tickets', tribe_callback( 'extension.per_event_checkin.api_handler', 'add_community_tickets_api_box' ) );
 	}
 
 	/**


### PR DESCRIPTION
Individual API for each event is now shown on the Community Event edit pages:

<img width="951" alt="Screen Shot 2021-06-28 at 4 08 03 PM" src="https://user-images.githubusercontent.com/7523321/123620554-2f615280-d82c-11eb-8e3f-de3cbb4dd46f.png">

